### PR TITLE
Create 005_lightning_network_whitepaper.md

### DIFF
--- a/research/005_lightning_network_whitepaper.md
+++ b/research/005_lightning_network_whitepaper.md
@@ -1,0 +1,37 @@
+## Metadata
+
+| Attribute | Data |
+|---|---|
+| Title | The Bitcoin Lightning Network: Scalable Off-Chain Instant Payments |
+| DOI |  |
+| Published Date (YYYY-MM-DD) | 2016-01-14 |
+| License (e.g. CC-BY) | Unlicensed |
+
+## Authors
+
+| Name | Email | ENS |
+|---|---|---|
+| Joseph Poon | joseph@lightning.network |  |
+| Thaddeus Dryja | rx@awsomnet.org |  |
+
+## Data
+
+| Attribute | URL |
+|---|---|
+| PDF/Article | https://lightning.network/lightning-network-paper.pdf |
+| Repository | https://github.com/lightningnetwork/lnd |
+| Reproducible Notebook |  |
+
+## Citations
+
+### Cites
+
+| ID | Title |
+|---|---|
+| 1 | Bitcoin: A Peer-to-Peer Electronic Cash System |
+
+### Cited By
+
+| ID | Title |
+|---|---|
+|  |  |


### PR DESCRIPTION
Lighting Network whitepaper doesn't have any figures that need reproducibility. They have a [repository](https://github.com/lightningnetwork/paper) for generating the whitepaper but they also have a repo for the protocol implementation -- using that as the paper repository since it's a better code adjunct to the PDF for the lightning network specification.

## Submission Details

Research Paper Title: The Bitcoin Lightning Network: Scalable Off-Chain Instant Payments

### Checklist
- [ ] I got permission from the paper author
- [X] I checked the licensing of the paper
